### PR TITLE
Fix memory leak while applying patches

### DIFF
--- a/detools/hdiffpatch.cpp
+++ b/detools/hdiffpatch.cpp
@@ -364,6 +364,8 @@ static PyObject *m_apply_patch(PyObject *self_p, PyObject* args_p)
         exit(1);
     }
 
+    free(temp_cache_p );
+
     return (byte_array_p);
 }
 


### PR DESCRIPTION
The cache wasn't being freed when the patch was applied.
Fixes #7.
