### PR TITLE
Misc. vuln fixes

### DIFF
--- a/c/detools.c
+++ b/c/detools.c
@@ -1081,7 +1081,15 @@ static int common_process_size(
         return (res);
     }
 
-    if (to_pos + (size_t)*size_p > to_size) {
+    if (*size_p < 0) {
+        return (-DETOOLS_CORRUPT_PATCH);
+    }
+
+    if (to_pos > to_size) {
+        return (-DETOOLS_CORRUPT_PATCH);
+    }
+
+    if (((size_t)*size_p) > (to_size - to_pos)) {
         return (-DETOOLS_CORRUPT_PATCH);
     }
 
@@ -1180,6 +1188,10 @@ static int process_dfpatch_size(struct detools_apply_patch_t *self_p)
 
     if (res != 0) {
         return (res);
+    }
+
+    if (size < 0) {
+        return (-DETOOLS_CORRUPT_PATCH);
     }
 
     if (size > 0) {
@@ -1758,6 +1770,10 @@ static int in_place_process_init_memory_size(
         return (res);
     }
 
+    if (memory_size < 0) {
+        return (-DETOOLS_CORRUPT_PATCH);
+    }
+
     self_p->memory_size = (size_t)memory_size;
     self_p->init_state = detools_apply_patch_in_place_init_state_segment_size_t;
     self_p->size.state = detools_unpack_usize_state_first_t;
@@ -1775,6 +1791,10 @@ static int in_place_process_init_segment_size(
 
     if (res != 0) {
         return (res);
+    }
+
+    if (segment_size <= 0) {
+        return (-DETOOLS_CORRUPT_PATCH);
     }
 
     self_p->segment_size = (size_t)segment_size;
@@ -1796,6 +1816,10 @@ static int in_place_process_init_shift_size(
         return (res);
     }
 
+    if (shift_size < 0) {
+        return (-DETOOLS_CORRUPT_PATCH);
+    }
+
     self_p->shift_size = (size_t)shift_size;
     self_p->init_state = detools_apply_patch_in_place_init_state_from_size_t;
     self_p->size.state = detools_unpack_usize_state_first_t;
@@ -1813,6 +1837,10 @@ static int in_place_process_init_from_size(
 
     if (res != 0) {
         return (res);
+    }
+
+    if (from_size < 0) {
+        return (-DETOOLS_CORRUPT_PATCH);
     }
 
     self_p->from_size = (size_t)from_size;
@@ -1844,6 +1872,12 @@ static int in_place_process_init_to_size(
     }
 
     if (to_size < 0) {
+        return (-DETOOLS_CORRUPT_PATCH);
+    }
+
+    if ((self_p->shift_size > self_p->memory_size)
+        || (self_p->from_size > self_p->memory_size)
+        || ((size_t)to_size > self_p->memory_size)) {
         return (-DETOOLS_CORRUPT_PATCH);
     }
 
@@ -1916,6 +1950,10 @@ static int in_place_process_dfpatch_size(
 
     if (res != 0) {
         return (res);
+    }
+
+    if (size < 0) {
+        return (-DETOOLS_CORRUPT_PATCH);
     }
 
     if (size > 0) {

--- a/c/tst/test_fuzzer.c
+++ b/c/tst/test_fuzzer.c
@@ -124,6 +124,47 @@ static int to_write(void *arg_p, const uint8_t *buf_p, size_t size)
     return (0);
 }
 
+static uint8_t mem_buf[256];
+
+static int mem_read(void *arg_p, void *dst_p, uintptr_t src, size_t size)
+{
+    (void)arg_p;
+
+    if ((src + size) > sizeof(mem_buf)) {
+        return (-1);
+    }
+
+    memcpy(dst_p, &mem_buf[src], size);
+
+    return (0);
+}
+
+static int mem_write(void *arg_p, uintptr_t dst, void *src_p, size_t size)
+{
+    (void)arg_p;
+
+    if ((dst + size) > sizeof(mem_buf)) {
+        return (-1);
+    }
+
+    memcpy(&mem_buf[dst], src_p, size);
+
+    return (0);
+}
+
+static int mem_erase(void *arg_p, uintptr_t addr, size_t size)
+{
+    (void)arg_p;
+
+    if ((addr + size) > sizeof(mem_buf)) {
+        return (-1);
+    }
+
+    memset(&mem_buf[addr], 0xff, size);
+
+    return (0);
+}
+
 static void test_one(const uint8_t *patch_buf_p,
                      size_t patch_size,
                      int process_res,
@@ -147,6 +188,39 @@ static void test_one(const uint8_t *patch_buf_p,
     }
 
     res = detools_apply_patch_finalize(&apply_patch);
+
+    WITH_MESSAGE("Failed with '%s' (%d).", detools_error_as_string(res), res) {
+        ASSERT_EQ(res, finalize_res);
+    }
+}
+
+static void test_one_in_place(const uint8_t *patch_buf_p,
+                              size_t patch_size,
+                              int process_res,
+                              int finalize_res)
+{
+    struct detools_apply_patch_in_place_t apply_patch;
+    int res;
+
+    memset(&mem_buf[0], 0, sizeof(mem_buf));
+
+    res = detools_apply_patch_in_place_init(&apply_patch,
+                                            mem_read,
+                                            mem_write,
+                                            mem_erase,
+                                            NULL,
+                                            NULL,
+                                            patch_size,
+                                            NULL);
+    ASSERT_EQ(res, 0);
+
+    res = detools_apply_patch_in_place_process(&apply_patch, patch_buf_p, patch_size);
+
+    WITH_MESSAGE("Failed with '%s' (%d).", detools_error_as_string(res), res) {
+        ASSERT_EQ(res, process_res);
+    }
+
+    res = detools_apply_patch_in_place_finalize(&apply_patch);
 
     WITH_MESSAGE("Failed with '%s' (%d).", detools_error_as_string(res), res) {
         ASSERT_EQ(res, finalize_res);
@@ -249,4 +323,40 @@ TEST(size_overflow_header)
              sizeof(patch),
              -DETOOLS_CORRUPT_PATCH_OVERFLOW,
              -DETOOLS_ALREADY_FAILED);
+}
+
+TEST(negative_diff_size)
+{
+    const uint8_t patch[] = {
+        0x00, 0x01, 0x00, 0x41, 0x01, 0x41, 0x00
+    };
+
+    test_one(&patch[0],
+             sizeof(patch),
+             -DETOOLS_CORRUPT_PATCH,
+             -DETOOLS_ALREADY_FAILED);
+}
+
+TEST(in_place_zero_segment_size)
+{
+    const uint8_t patch[] = {
+        0x10, 0x01, 0x00, 0x00, 0x01, 0x01
+    };
+
+    test_one_in_place(&patch[0],
+                      sizeof(patch),
+                      -DETOOLS_CORRUPT_PATCH,
+                      -DETOOLS_ALREADY_FAILED);
+}
+
+TEST(in_place_shift_larger_than_memory)
+{
+    const uint8_t patch[] = {
+        0x10, 0x01, 0x01, 0x02, 0x01, 0x01
+    };
+
+    test_one_in_place(&patch[0],
+                      sizeof(patch),
+                      -DETOOLS_CORRUPT_PATCH,
+                      -DETOOLS_ALREADY_FAILED);
 }

--- a/detools/apply.py
+++ b/detools/apply.py
@@ -86,10 +86,33 @@ class PatchReader(object):
         return self.decompressor.eof
 
 
+def ensure_non_negative_size(name, size):
+    if size < 0:
+        raise Error('Expected {} >= 0, but got {}.'.format(name, size))
+
+    return size
+
+
+def ensure_positive_size(name, size):
+    if size <= 0:
+        raise Error('Expected {} > 0, but got {}.'.format(name, size))
+
+    return size
+
+
+def read_exact(fin, size, message):
+    data = fin.read(size)
+
+    if len(data) != size:
+        raise Error(message)
+
+    return data
+
+
 def iter_chunks(patch_reader, to_pos, to_size, message):
     size = unpack_size(patch_reader)
 
-    if to_pos + size > to_size:
+    if size < 0 or to_pos + size > to_size:
         raise Error(message)
 
     offset = 0
@@ -159,7 +182,7 @@ def read_header_sequential(fpatch):
                                                          patch_type))
 
     compression = convert_compression(compression)
-    to_size = unpack_size(fpatch)
+    to_size = ensure_non_negative_size('to size', unpack_size(fpatch))
 
     return compression, to_size
 
@@ -182,8 +205,8 @@ def read_header_hdiffpatch(fpatch):
                                                          patch_type))
 
     compression = convert_compression(compression)
-    to_size = unpack_size(fpatch)
-    patch_size = unpack_size(fpatch)
+    to_size = ensure_non_negative_size('to size', unpack_size(fpatch))
+    patch_size = ensure_non_negative_size('patch size', unpack_size(fpatch))
 
     return compression, to_size, patch_size
 
@@ -206,11 +229,29 @@ def read_header_in_place(fpatch):
                                                          patch_type))
 
     compression = convert_compression(compression)
-    memory_size = unpack_size(fpatch)
-    segment_size = unpack_size(fpatch)
-    shift_size = unpack_size(fpatch)
-    from_size = unpack_size(fpatch)
-    to_size = unpack_size(fpatch)
+    memory_size = ensure_non_negative_size('memory size', unpack_size(fpatch))
+    segment_size = ensure_positive_size('segment size', unpack_size(fpatch))
+    shift_size = ensure_non_negative_size('shift size', unpack_size(fpatch))
+    from_size = ensure_non_negative_size('from size', unpack_size(fpatch))
+    to_size = ensure_non_negative_size('to size', unpack_size(fpatch))
+
+    if shift_size > memory_size:
+        raise Error(
+            'Expected shift size <= memory size, but got {} and {}.'.format(
+                shift_size,
+                memory_size))
+
+    if from_size > memory_size:
+        raise Error(
+            'Expected from size <= memory size, but got {} and {}.'.format(
+                from_size,
+                memory_size))
+
+    if to_size > memory_size:
+        raise Error(
+            'Expected to size <= memory size, but got {} and {}.'.format(
+                to_size,
+                memory_size))
 
     return compression, memory_size, segment_size, shift_size, from_size, to_size
 
@@ -240,6 +281,10 @@ def read_header_bsdiff(fpatch):
     ctrl_size = offtin(fpatch.read(8))
     diff_size = offtin(fpatch.read(8))
     to_size = offtin(fpatch.read(8))
+
+    ensure_non_negative_size('control size', ctrl_size)
+    ensure_non_negative_size('diff size', diff_size)
+    ensure_non_negative_size('to size', to_size)
 
     return ctrl_size, diff_size, to_size
 
@@ -272,7 +317,8 @@ def apply_patch_in_place_segment(fmem,
 
     """
 
-    dfpatch_size = unpack_size(patch_reader)
+    dfpatch_size = ensure_non_negative_size('data format patch size',
+                                            unpack_size(patch_reader))
 
     if dfpatch_size > 0:
         raise NotImplementedError()
@@ -285,7 +331,10 @@ def apply_patch_in_place_segment(fmem,
                                                        to_pos,
                                                        to_size):
             fmem.seek(from_offset, os.SEEK_SET)
-            from_data = fmem.read(chunk_size)
+            from_data = read_exact(
+                fmem,
+                chunk_size,
+                'Patch diff data exceeds available source data.')
             from_offset += chunk_size
             fmem.seek(to_offset + to_pos, os.SEEK_SET)
             fmem.write(bsdiff.add_bytes(patch_data, from_data))
@@ -305,10 +354,11 @@ def apply_patch_in_place_segment(fmem,
 
 
 def create_data_format_readers(patch_reader, ffrom, to_size):
-    dfpatch_size = unpack_size(patch_reader)
+    dfpatch_size = ensure_non_negative_size('data format patch size',
+                                            unpack_size(patch_reader))
 
     if dfpatch_size > 0:
-        data_format = unpack_size(patch_reader)
+        data_format = ensure_non_negative_size('data format', unpack_size(patch_reader))
         patch = patch_reader.decompress(dfpatch_size)
         dfdiff, ffrom = create_readers(data_format, ffrom, patch, to_size)
 
@@ -361,11 +411,17 @@ def apply_patch_sequential(ffrom, fpatch, fto):
         for chunk_size, patch_data in iter_diff_chunks(patch_reader,
                                                        to_pos,
                                                        to_size):
-            from_data = ffrom.read(chunk_size)
+            from_data = read_exact(
+                ffrom,
+                chunk_size,
+                'Patch diff data exceeds available source data.')
             data = bsdiff.add_bytes(patch_data, from_data)
 
             if dfdiff is not None:
-                dfdiff_data = dfdiff.read(chunk_size)
+                dfdiff_data = read_exact(
+                    dfdiff,
+                    chunk_size,
+                    'Patch diff data exceeds available source data.')
                 data = bsdiff.add_bytes(data, dfdiff_data)
 
             fto.write(data)
@@ -378,7 +434,10 @@ def apply_patch_sequential(ffrom, fpatch, fto):
             data = patch_data
 
             if dfdiff is not None:
-                dfdiff_data = dfdiff.read(chunk_size)
+                dfdiff_data = read_exact(
+                    dfdiff,
+                    chunk_size,
+                    'Patch diff data exceeds available source data.')
                 data = bsdiff.add_bytes(data, dfdiff_data)
 
             fto.write(data)

--- a/detools/bsdiff.c
+++ b/detools/bsdiff.c
@@ -27,10 +27,59 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <limits.h>
 #include <string.h>
 #include <Python.h>
 
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
+
+static int validate_int32_length(Py_ssize_t size, const char *name_p)
+{
+    if (size > INT32_MAX) {
+        PyErr_Format(PyExc_ValueError, "%s is too large.", name_p);
+
+        return (-1);
+    }
+
+    return (0);
+}
+
+static int validate_suffix_array(Py_buffer *suffix_array_view_p,
+                                 Py_ssize_t from_size)
+{
+    Py_ssize_t count;
+    Py_ssize_t i;
+    int32_t *suffix_array_p;
+
+    if ((suffix_array_view_p->len % (Py_ssize_t)sizeof(int32_t)) != 0) {
+        PyErr_SetString(PyExc_ValueError,
+                        "Suffix array length must be a multiple of 4 bytes.");
+
+        return (-1);
+    }
+
+    count = suffix_array_view_p->len / (Py_ssize_t)sizeof(int32_t);
+
+    if (count < from_size + 1) {
+        PyErr_SetString(PyExc_ValueError, "Suffix array buffer is too small.");
+
+        return (-1);
+    }
+
+    suffix_array_p = suffix_array_view_p->buf;
+
+    for (i = 0; i < from_size + 1; i++) {
+        if ((suffix_array_p[i] < 0) || (suffix_array_p[i] > from_size)) {
+            PyErr_Format(PyExc_ValueError,
+                         "Suffix array entry %zd is out of range.",
+                         i);
+
+            return (-1);
+        }
+    }
+
+    return (0);
+}
 
 static int32_t matchlen(uint8_t *from_p,
                         int32_t from_size,
@@ -492,6 +541,29 @@ static PyObject *m_create_patch(PyObject *self_p, PyObject *args_p)
         return (NULL);
     }
 
+    res = validate_int32_length(from_view.len, "from_data");
+
+    if (res != 0) {
+        goto err1;
+    }
+
+    res = validate_int32_length(to_view.len, "to_data");
+
+    if (res != 0) {
+        goto err1;
+    }
+
+    if (de_view.len < to_view.len) {
+        PyErr_SetString(PyExc_ValueError, "Diff buffer is too small.");
+        goto err1;
+    }
+
+    res = validate_suffix_array(&suffix_array_view, from_view.len);
+
+    if (res != 0) {
+        goto err1;
+    }
+
     list_p = PyList_New(0);
 
     if (list_p == NULL) {
@@ -583,7 +655,7 @@ static PyObject *m_add_bytes(PyObject *self_p, PyObject *args_p)
     if (first_view.len != second_view.len) {
         PyErr_SetString(PyExc_ValueError, "Lengths must be equal.");
 
-        return (NULL);
+        goto err1;
     }
 
     byte_array_p = PyByteArray_FromStringAndSize("", 1);

--- a/detools/compression/crle.py
+++ b/detools/compression/crle.py
@@ -140,6 +140,8 @@ class CrleDecompressor(object):
         self._indata = b''
         self._outdata = b''
         self._number_of_scattered_bytes_left = 0
+        self._number_of_repeated_bytes_left = 0
+        self._repeated_byte = b''
 
     def decompress(self, data, size):
         """Decompress up to size bytes.
@@ -154,7 +156,28 @@ class CrleDecompressor(object):
 
         self._indata += data
         self._number_of_indata_bytes_left -= len(data)
-        self._outdata += self.decompress_segments()
+        target_size = max(size, 1)
+
+        while len(self._outdata) < target_size:
+            previous_state = (
+                len(self._indata),
+                self._number_of_scattered_bytes_left,
+                self._number_of_repeated_bytes_left
+            )
+
+            try:
+                chunk = self.decompress_segment(target_size - len(self._outdata))
+            except IndexError:
+                break
+
+            self._outdata += chunk
+
+            if previous_state == (
+                    len(self._indata),
+                    self._number_of_scattered_bytes_left,
+                    self._number_of_repeated_bytes_left):
+                break
+
         data = self._outdata[:size]
         self._outdata = self._outdata[size:]
 
@@ -162,65 +185,118 @@ class CrleDecompressor(object):
 
     @property
     def needs_input(self):
-        return len(self._outdata) == 0 and not self.eof
+        return not self.eof and not self._can_make_progress_without_input()
 
     @property
     def eof(self):
         return (self._number_of_indata_bytes_left == 0
+                and self._number_of_scattered_bytes_left == 0
+                and self._number_of_repeated_bytes_left == 0
                 and len(self._outdata) == 0
                 and len(self._indata) == 0)
 
-    def decompress_segments(self):
-        segments = []
+    def _can_make_progress_without_input(self):
+        if len(self._outdata) > 0:
+            return True
 
-        try:
-            while True:
-                segments.append(self.decompress_segment())
-        except IndexError:
-            pass
+        if self._number_of_repeated_bytes_left > 0:
+            return True
 
-        return b''.join(segments)
+        if self._number_of_scattered_bytes_left > 0:
+            return len(self._indata) > 0
 
-    def decompress_segment(self):
+        if len(self._indata) == 0:
+            return False
+
+        kind = self._indata[0]
+
+        if kind == SCATTERED:
+            try:
+                length, offset = unpack_size(self._indata, 1)
+            except IndexError:
+                return False
+
+            return length == 0 or len(self._indata) > offset
+        elif kind == REPEATED:
+            try:
+                _, offset = unpack_size(self._indata, 1)
+            except IndexError:
+                return False
+
+            return len(self._indata) >= offset + 1
+        else:
+            return True
+
+    def decompress_segment(self, size):
         """Try to decompress a segment. Raises IndexError if not enough data
         is available..
 
         """
 
-        if self._number_of_scattered_bytes_left == 0:
-            kind = self._indata[0]
+        if self._number_of_repeated_bytes_left > 0:
+            repetitions = min(size, self._number_of_repeated_bytes_left)
+            self._number_of_repeated_bytes_left -= repetitions
 
-            if kind == SCATTERED:
-                length, offset = unpack_size(self._indata, 1)
-                remaining = (offset + length - len(self._indata))
+            return repetitions * self._repeated_byte
 
-                if remaining > 0:
-                    self._number_of_scattered_bytes_left = remaining
-                    length -= remaining
+        if self._number_of_scattered_bytes_left > 0:
+            if len(self._indata) == 0:
+                raise IndexError
 
-                repetitions = 1
-            elif kind == REPEATED:
-                repetitions, offset = unpack_size(self._indata, 1)
-                length = 1
-            else:
-                raise Error(
-                    'Expected kind scattered(0) or repeated(1), but got {}.'.format(
-                        kind))
-        elif len(self._indata) > 0:
-            length = min(len(self._indata), self._number_of_scattered_bytes_left)
-            offset = 0
-            repetitions = 1
+            length = min(size, len(self._indata), self._number_of_scattered_bytes_left)
+            data = self._indata[:length]
+            self._indata = self._indata[length:]
             self._number_of_scattered_bytes_left -= length
+
+            return data
+
+        if len(self._indata) == 0:
+            raise IndexError
+
+        kind = self._indata[0]
+
+        if kind == SCATTERED:
+            total_length, offset = unpack_size(self._indata, 1)
+
+            if len(self._indata) < offset:
+                raise IndexError
+
+            available = len(self._indata) - offset
+
+            if total_length == 0:
+                self._indata = self._indata[offset:]
+
+                return b''
+
+            if available == 0:
+                raise IndexError
+
+            length = min(size, total_length, available)
+            data = self._indata[offset:offset + length]
+            self._indata = self._indata[offset + length:]
+            self._number_of_scattered_bytes_left = total_length - length
+
+            return data
+        elif kind == REPEATED:
+            repetitions, offset = unpack_size(self._indata, 1)
+
+            if len(self._indata) < offset + 1:
+                raise IndexError
+
+            self._repeated_byte = self._indata[offset:offset + 1]
+            self._indata = self._indata[offset + 1:]
+
+            if repetitions == 0:
+                return b''
+
+            length = min(size, repetitions)
+            self._number_of_repeated_bytes_left = repetitions - length
+
+            return length * self._repeated_byte
         else:
-            raise IndexError
-
-        if len(self._indata) < offset + length:
-            raise IndexError
-
-        data = repetitions * self._indata[offset:offset + length]
-        self._indata = self._indata[offset + length:]
-
-        return data
+            raise Error(
+                'Expected kind scattered(0) or repeated(1), but got {}.'.format(
+                    kind))
 
 
 def pack_size(value):

--- a/detools/suffix_array.c
+++ b/detools/suffix_array.c
@@ -26,6 +26,7 @@
  */
 
 #include <stdint.h>
+#include <limits.h>
 #include <Python.h>
 #include "sais/sais.h"
 #include "libdivsufsort/divsufsort.h"
@@ -33,6 +34,35 @@
 typedef int32_t (*create_t)(const uint8_t *buf_p,
                             int32_t *suffix_array_p,
                             int32_t length);
+
+static int validate_create_args(Py_buffer *from_view_p,
+                                Py_buffer *suffix_array_view_p)
+{
+    Py_ssize_t required_size;
+
+    if (from_view_p->len > INT32_MAX) {
+        PyErr_SetString(PyExc_ValueError, "from_data is too large.");
+
+        return (-1);
+    }
+
+    if ((suffix_array_view_p->len % (Py_ssize_t)sizeof(int32_t)) != 0) {
+        PyErr_SetString(PyExc_ValueError,
+                        "Suffix array length must be a multiple of 4 bytes.");
+
+        return (-1);
+    }
+
+    required_size = (from_view_p->len + 1) * (Py_ssize_t)sizeof(int32_t);
+
+    if (suffix_array_view_p->len < required_size) {
+        PyErr_SetString(PyExc_ValueError, "Suffix array buffer is too small.");
+
+        return (-1);
+    }
+
+    return (0);
+}
 
 static PyObject *create(PyObject *self_p,
                         PyObject* args_p,
@@ -67,6 +97,12 @@ static PyObject *create(PyObject *self_p,
 
     if (res == -1) {
         goto err1;
+    }
+
+    res = validate_create_args(&from_view, &suffix_array_view);
+
+    if (res != 0) {
+        goto err2;
     }
 
     suffix_array_p = (int32_t *)suffix_array_view.buf;

--- a/tests/test_apply_security.py
+++ b/tests/test_apply_security.py
@@ -1,0 +1,138 @@
+import unittest
+from io import BytesIO
+
+import detools
+from detools.common import pack_size
+from detools.create import pack_header
+
+
+def make_sequential_patch(*chunks):
+    patch = bytearray()
+    patch += pack_header(0, 0)
+    patch += pack_size(1)
+
+    for chunk in chunks:
+        patch += chunk
+
+    return bytes(patch)
+
+
+def make_in_place_patch(memory_size,
+                        segment_size,
+                        shift_size,
+                        from_size,
+                        to_size,
+                        *chunks):
+    patch = bytearray()
+    patch += pack_header(1, 0)
+    patch += pack_size(memory_size)
+    patch += pack_size(segment_size)
+    patch += pack_size(shift_size)
+    patch += pack_size(from_size)
+    patch += pack_size(to_size)
+
+    for chunk in chunks:
+        patch += chunk
+
+    return bytes(patch)
+
+
+class RecordingBytesIO(BytesIO):
+
+    def __init__(self, data):
+        super().__init__(data)
+        self.read_args = []
+
+    def read(self, size=-1):
+        self.read_args.append(size)
+
+        return super().read(size)
+
+
+class ApplySecurityTest(unittest.TestCase):
+
+    def test_apply_patch_rejects_negative_diff_size(self):
+        patch = make_sequential_patch(
+            pack_size(0),
+            pack_size(-1),
+            pack_size(1),
+            b'A',
+            pack_size(0))
+
+        with self.assertRaisesRegex(detools.Error, 'Patch diff data too long'):
+            detools.apply_patch(BytesIO(b''), BytesIO(patch), BytesIO())
+
+    def test_apply_patch_rejects_negative_extra_size(self):
+        patch = make_sequential_patch(
+            pack_size(0),
+            pack_size(1),
+            b'\x01',
+            pack_size(-1),
+            pack_size(0))
+
+        with self.assertRaisesRegex(detools.Error, 'Patch extra data too long'):
+            detools.apply_patch(BytesIO(b'@'), BytesIO(patch), BytesIO())
+
+    def test_apply_patch_rejects_negative_dfpatch_size(self):
+        patch = make_sequential_patch(pack_size(-1))
+
+        with self.assertRaisesRegex(detools.Error,
+                                    'Expected data format patch size >= 0'):
+            detools.apply_patch(BytesIO(b''), BytesIO(patch), BytesIO())
+
+    def test_apply_patch_in_place_rejects_negative_from_size_before_read(self):
+        patch = make_in_place_patch(
+            1,
+            1,
+            0,
+            -1,
+            1,
+            pack_size(0),
+            pack_size(0),
+            pack_size(1),
+            b'A',
+            pack_size(0))
+        memory = RecordingBytesIO(b'Z')
+
+        with self.assertRaisesRegex(detools.Error, 'Expected from size >= 0'):
+            detools.apply_patch_in_place(memory, BytesIO(patch))
+
+        self.assertEqual(memory.read_args, [])
+
+    def test_apply_patch_in_place_rejects_zero_segment_size(self):
+        patch = make_in_place_patch(1, 0, 0, 1, 1)
+
+        with self.assertRaisesRegex(detools.Error, 'Expected segment size > 0'):
+            detools.apply_patch_in_place(BytesIO(b'Z'), BytesIO(patch))
+
+    def test_apply_patch_in_place_rejects_shift_larger_than_memory(self):
+        patch = make_in_place_patch(1, 1, 2, 1, 1)
+
+        with self.assertRaisesRegex(detools.Error, 'Expected shift size <= memory size'):
+            detools.apply_patch_in_place(BytesIO(b'Z'), BytesIO(patch))
+
+    def test_apply_patch_in_place_rejects_short_source_reads(self):
+        patch = make_in_place_patch(
+            1,
+            1,
+            1,
+            1,
+            1,
+            pack_size(0),
+            pack_size(1),
+            b'\x00',
+            pack_size(0),
+            pack_size(0))
+
+        with self.assertRaisesRegex(detools.Error,
+                                    'Patch diff data exceeds available source data'):
+            detools.apply_patch_in_place(BytesIO(b'Z'), BytesIO(patch))
+
+    def test_apply_patch_rejects_invalid_heatshrink_header(self):
+        patch = bytearray()
+        patch += pack_header(0, 4)
+        patch += pack_size(1)
+        patch += b'\xff'
+
+        with self.assertRaisesRegex(detools.Error, 'Patch decompression failed'):
+            detools.apply_patch(BytesIO(b''), BytesIO(patch), BytesIO())

--- a/tests/test_bsdiff.py
+++ b/tests/test_bsdiff.py
@@ -1,5 +1,8 @@
 import unittest
 import struct
+import mmap
+import tempfile
+from contextlib import contextmanager
 
 import detools.bsdiff
 
@@ -13,6 +16,18 @@ def suffix_array_list_to_bytearray(suffix_array):
     return bytearray().join([
         struct.pack('=i', value) for value in suffix_array
     ])
+
+
+@contextmanager
+def sparse_mmap(size, access):
+    with tempfile.TemporaryFile() as file_p:
+        file_p.truncate(size)
+        map_p = mmap.mmap(file_p.fileno(), size, access=access)
+
+        try:
+            yield map_p
+        finally:
+            map_p.close()
 
 
 class DetoolsBsdiffTest(unittest.TestCase):
@@ -71,6 +86,42 @@ class DetoolsBsdiffTest(unittest.TestCase):
                                             to_data,
                                             bytearray(4 * (len(from_data) + 1))),
                 chunks)
+
+    def test_bsdiff_rejects_too_small_diff_buffer(self):
+        suffix_array = suffix_array_list_to_bytearray([1, 0])
+
+        with self.assertRaisesRegex(ValueError, 'Diff buffer is too small'):
+            detools.bsdiff.create_patch(suffix_array, b'A', b'BC', bytearray(1))
+
+    def test_bsdiff_rejects_invalid_suffix_array_entries(self):
+        suffix_array = suffix_array_list_to_bytearray([1, 999])
+
+        with self.assertRaisesRegex(ValueError, 'Suffix array entry 1 is out of range'):
+            detools.bsdiff.create_patch(suffix_array, b'A', b'B', bytearray(2))
+
+    def test_bsdiff_rejects_input_larger_than_int32(self):
+        huge_size = 2 ** 31
+        suffix_array_size = 4 * (huge_size + 1)
+
+        with sparse_mmap(huge_size, mmap.ACCESS_READ) as from_mmap:
+            with sparse_mmap(suffix_array_size, mmap.ACCESS_WRITE) as suffix_array:
+                with self.assertRaisesRegex(ValueError, 'from_data is too large'):
+                    detools.bsdiff.create_patch(suffix_array,
+                                                from_mmap,
+                                                b'A',
+                                                bytearray(1))
+
+    def test_add_bytes_releases_buffers_on_error(self):
+        first = bytearray(b'A')
+        second = bytearray()
+
+        with self.assertRaisesRegex(ValueError, 'Lengths must be equal'):
+            detools.bsdiff.add_bytes(first, second)
+
+        first.extend(b'B')
+        second.extend(b'C')
+        self.assertEqual(first, b'AB')
+        self.assertEqual(second, b'C')
 
 
 if __name__ == '__main__':

--- a/tests/test_crle.py
+++ b/tests/test_crle.py
@@ -3,6 +3,7 @@ import unittest
 import detools
 from detools.create import CrleCompressor
 from detools.apply import CrleDecompressor
+from detools.compression.crle import pack_size
 
 
 class DetoolsCrleTest(unittest.TestCase):
@@ -106,6 +107,21 @@ class DetoolsCrleTest(unittest.TestCase):
 
         self.assertEqual(decompressor.decompress(compressed + b'B', 1), b'A')
         self.assertEqual(decompressor.eof, True)
+
+    def test_decompress_repeated_segment_incrementally(self):
+        compressed = b'\x01' + pack_size(100000) + b'A'
+        decompressor = CrleDecompressor(len(compressed))
+
+        self.assertEqual(decompressor.decompress(compressed, 1), b'A')
+        self.assertEqual(len(decompressor._outdata), 0)
+        self.assertEqual(decompressor.decompress(b'', 1), b'A')
+
+    def test_decompress_scattered_segment_incrementally(self):
+        compressed = b'\x00' + pack_size(100000) + b'A'
+        decompressor = CrleDecompressor(len(compressed))
+
+        self.assertEqual(decompressor.decompress(compressed, 1), b'A')
+        self.assertEqual(len(decompressor._outdata), 0)
 
 
 if __name__ == '__main__':

--- a/tests/test_suffix_array.py
+++ b/tests/test_suffix_array.py
@@ -1,5 +1,8 @@
 import unittest
 import struct
+import mmap
+import tempfile
+from contextlib import contextmanager
 
 import detools.sais
 
@@ -13,6 +16,18 @@ def suffix_array_list_to_bytearray(suffix_array):
     return bytearray().join([
         struct.pack('=i', value) for value in suffix_array
     ])
+
+
+@contextmanager
+def sparse_mmap(size, access):
+    with tempfile.TemporaryFile() as file_p:
+        file_p.truncate(size)
+        map_p = mmap.mmap(file_p.fileno(), size, access=access)
+
+        try:
+            yield map_p
+        finally:
+            map_p.close()
 
 
 class DetoolsSuffixArrayTest(unittest.TestCase):
@@ -56,6 +71,19 @@ class DetoolsSuffixArrayTest(unittest.TestCase):
 
             detools.suffix_array.divsufsort(data, suffix_array)
             self.assertEqual(suffix_array, expected)
+
+    def test_suffix_array_rejects_too_small_output_buffer(self):
+        with self.assertRaisesRegex(ValueError, 'Suffix array buffer is too small'):
+            detools.suffix_array.sais(b'A', bytearray(4))
+
+    def test_suffix_array_rejects_input_larger_than_int32(self):
+        huge_size = 2 ** 31
+        suffix_array_size = 4 * (huge_size + 1)
+
+        with sparse_mmap(huge_size, mmap.ACCESS_READ) as data:
+            with sparse_mmap(suffix_array_size, mmap.ACCESS_WRITE) as suffix_array:
+                with self.assertRaisesRegex(ValueError, 'from_data is too large'):
+                    detools.suffix_array.divsufsort(data, suffix_array)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Summary

This PR fixes multiple vulnerabilities across the C apply path, the Python apply path, and the native Python extensions used during patch creation.

The common issue behind most of the real findings was that malformed patch metadata or caller-provided native buffers were not being rejected early enough. In practice that meant negative decoded sizes, impossible in-place patch geometry, oversized logical CRLE segments, and unchecked native buffers could reach arithmetic, reads, or writes that assumed the inputs were already valid.

This change hardens those boundaries. Valid patches should behave the same as before, but malformed or adversarial inputs now fail early and predictably instead of being normalized by casts, propagated into invalid geometry, or passed through to unsafe native code.

## Breakdown

- **C library: negative decoded chunk sizes bypassed bounds validation**
  In `c/detools.c`, decoded sizes from the patch stream could be negative and still pass through `common_process_size()` after an implicit cast to `size_t`.

- **C library: in-place patches could encode `segment_size = 0`**
  In the in-place apply header, `segment_size` was not rejected before being used in segment math.

- **C library: in-place patches could encode `shift_size > memory_size`**
  The in-place shift calculation assumed a valid layout and did not reject impossible memory geometry before using it.

- **Python apply path: negative sequential / in-place / bsdiff sizes were not rejected consistently**
  `detools/apply.py` trusted several signed size fields from patch headers and chunk metadata longer than it should have.

- **Python apply path: negative `from_size` could reach file reads**
  In the in-place Python apply path, a negative decoded `from_size` could become `read(-N)` behavior on file-like objects.

- **Python apply path: short diff reads failed too late**
  During in-place segment application, a short source read could continue until `bsdiff.add_bytes()` tripped on a length mismatch, leaving the failure mode too deep into the apply flow.

- **CRLE decompressor buffered attacker-controlled logical output**
  In `detools/compression/crle.py`, repeated and scattered segments could expand into large `_outdata` buffers even when the caller only requested a small amount of output.

- **`bsdiff` native wrapper trusted caller-provided diff buffers**
  `detools/bsdiff.c` did not verify that the scratch diff buffer was large enough for `to_data`.

- **`bsdiff` native wrapper trusted oversized inputs**
  Inputs larger than the algorithm’s `int32_t` limits could be truncated before reaching the core bsdiff logic.

- **`bsdiff` native wrapper trusted suffix-array contents**
  Caller-provided suffix-array entries were used as offsets without validating that they were in range.

- **`suffix_array` native wrapper did not validate output buffer sizing**
  `detools.suffix_array.sais()` and `divsufsort()` assumed the caller had provided a large enough output buffer.

- **`bsdiff.add_bytes()` leaked Python buffer exports on one error path**
  The length-mismatch path returned without releasing acquired buffers.

## Impact

- **Negative decoded chunk sizes in the C apply path**
  A crafted patch could bypass the intended size bound checks and drive invalid apply behavior in the low-level C patch path.

- **`segment_size = 0` in in-place C apply**
  A crafted in-place patch could drive divide-by-zero style behavior and invalid segment processing.

- **`shift_size > memory_size` in in-place C apply**
  A crafted in-place patch could push the memory-shift logic into invalid geometry and nonsensical offsets.

- **Negative sizes in the Python apply path**
  Corrupt patches could slip past expected bounds checks and fail later in less predictable ways.

- **Negative `from_size` in Python in-place apply**
  A crafted patch could trigger oversized reads from the source object, which is especially bad for constrained environments or unusual file-like wrappers.

- **Short reads in Python in-place diff application**
  Corrupt patches could fail mid-apply with a low-level mismatch instead of being rejected as invalid patch input up front.

- **CRLE output buffering**
  A crafted CRLE stream could force the decompressor to buffer far more logical output than the caller requested, creating an avoidable resource-exhaustion vector.

- **Unchecked diff scratch buffers in `bsdiff`**
  Callers of the native patch-creation helper could trigger out-of-bounds native writes with undersized buffers.

- **Oversized native inputs**
  Inputs above the underlying algorithm limits could truncate into invalid negative or wrapped values before reaching the search logic.

- **Unchecked suffix-array contents**
  Malformed suffix arrays could drive out-of-range native reads and undefined behavior in patch creation.

- **Unchecked suffix-array output buffers**
  Callers could hand the wrapper too-small output buffers and trigger native memory corruption.

- **Leaked buffer exports in `add_bytes()`**
  Repeated error-path use could accumulate Python-side resource leakage and leave mutable buffers pinned unexpectedly.

## Testing

- Added direct regression tests for the C-library malformed patch cases in `c/tst/test_fuzzer.c`.
- Added Python security regressions in `tests/test_apply_security.py` covering:
  - negative diff / extra / data-format sizes
  - invalid in-place header values
  - short source reads during in-place diff application
  - invalid heatshrink headers
- Added CRLE regressions in `tests/test_crle.py` to verify repeated and scattered segments now decompress incrementally instead of over-buffering.
- Added native wrapper regressions in `tests/test_bsdiff.py` covering:
  - undersized diff buffers
  - invalid suffix-array entries
  - oversized inputs past `INT32_MAX`
  - the `add_bytes()` buffer-release error path
- Added native wrapper regressions in `tests/test_suffix_array.py` covering:
  - undersized output buffers
  - oversized inputs past `INT32_MAX`
